### PR TITLE
Fix issue 3: incorrect type conversion on .round int to float

### DIFF
--- a/numeric.c
+++ b/numeric.c
@@ -5788,10 +5788,7 @@ int_round(int argc, VALUE* argv, VALUE num)
     if (!rb_scan_args(argc, argv, "01:", &nd, &opt)) return num;
     ndigits = NUM2INT(nd);
     mode = rb_num_get_rounding_option(opt);
-    if (ndigits > 0) {
-	    return rb_Float(num);
-    }
-    if (ndigits == 0) {
+    if (ndigits >= 0) {
         return num;
     }
     return rb_int_round(num, ndigits, mode);
@@ -5860,10 +5857,8 @@ int_floor(int argc, VALUE* argv, VALUE num)
 
     if (!rb_check_arity(argc, 0, 1)) return num;
     ndigits = NUM2INT(argv[0]);
-    if (ndigits > 0) {
-	    return rb_Float(num);
-    }
-    if (ndigits == 0) {
+    if (ndigits >= 0)
+    {
         return num;
     }
     return rb_int_floor(num, ndigits);
@@ -5931,10 +5926,8 @@ int_ceil(int argc, VALUE* argv, VALUE num)
 
     if (!rb_check_arity(argc, 0, 1)) return num;
     ndigits = NUM2INT(argv[0]);
-    if (ndigits > 0) {
-	    return rb_Float(num);
-    }
-    if (ndigits == 0) {
+    if (ndigits >= 0)
+    {
         return num;
     }
     return rb_int_ceil(num, ndigits);
@@ -5970,10 +5963,8 @@ int_truncate(int argc, VALUE* argv, VALUE num)
 
     if (!rb_check_arity(argc, 0, 1)) return num;
     ndigits = NUM2INT(argv[0]);
-    if (ndigits > 0) {
-	    return rb_Float(num);
-    }
-    if (ndigits == 0) {
+    if (ndigits >= 0)
+    {
         return num;
     }
     return rb_int_truncate(num, ndigits);


### PR DESCRIPTION
Issue #3 fixed. Instead of transforming into a float when ndigits is greater than 0, it simply returns num if ndigits is greater or equal to 0. If it's a float, it will just run the int version of that function, so float conversion isn't needed.