### PR TITLE
Fix bug with casting ints to floats when rounding

### DIFF
--- a/numeric.c
+++ b/numeric.c
@@ -5788,10 +5788,7 @@ int_round(int argc, VALUE* argv, VALUE num)
     if (!rb_scan_args(argc, argv, "01:", &nd, &opt)) return num;
     ndigits = NUM2INT(nd);
     mode = rb_num_get_rounding_option(opt);
-    if (ndigits > 0) {
-	    return rb_Float(num);
-    }
-    if (ndigits == 0) {
+    if (ndigits >= 0) {
         return num;
     }
     return rb_int_round(num, ndigits, mode);
@@ -5860,10 +5857,7 @@ int_floor(int argc, VALUE* argv, VALUE num)
 
     if (!rb_check_arity(argc, 0, 1)) return num;
     ndigits = NUM2INT(argv[0]);
-    if (ndigits > 0) {
-	    return rb_Float(num);
-    }
-    if (ndigits == 0) {
+    if (ndigits >= 0) {
         return num;
     }
     return rb_int_floor(num, ndigits);
@@ -5931,10 +5925,7 @@ int_ceil(int argc, VALUE* argv, VALUE num)
 
     if (!rb_check_arity(argc, 0, 1)) return num;
     ndigits = NUM2INT(argv[0]);
-    if (ndigits > 0) {
-	    return rb_Float(num);
-    }
-    if (ndigits == 0) {
+    if (ndigits >= 0) {
         return num;
     }
     return rb_int_ceil(num, ndigits);
@@ -5970,10 +5961,7 @@ int_truncate(int argc, VALUE* argv, VALUE num)
 
     if (!rb_check_arity(argc, 0, 1)) return num;
     ndigits = NUM2INT(argv[0]);
-    if (ndigits > 0) {
-	    return rb_Float(num);
-    }
-    if (ndigits == 0) {
+    if (ndigits >= 0) {
         return num;
     }
     return rb_int_truncate(num, ndigits);


### PR DESCRIPTION
Addresses [#10](https://github.com/jonathansillito/CS301R-Ruby/issues/10).

Ints were being casted to a float when rounding didn't require it, this PR changes that.